### PR TITLE
FEATURE: Extended SilhouettesNodeTypePostProcessor.php - childNodes Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,15 @@ different names share similarities.
 
 The `Sitegeist.Silhouettes` package uses preconfigured
 property-configurations from the settings in multiple NodeTypes. This
-adds a way to centralize pererty-configuration for cases where mixins
+adds a way to centralize property-configuration for cases where mixins
 are not sufficient and settings shall be synchronized betweeen
 properties with different names.
+
+It is also possible to create silhouettes for childNode constraint
+configurations, e.g. to apply the same centralized constraints to different
+childNodes following the dry principle.
+This can also be useful when using a single NodeType package in different
+neos instances where the constraints may differcenate.
 
 The settings from the configured silhouette are merged with the
 configuration that is found in the nodeType with the local configuration
@@ -21,7 +27,7 @@ taking precedence over the silhouette.
 
 * Martin Ficzel - ficzel@sitegeist.de
 
-*The development and the public-releases of this package is generously sponsored 
+*The development and the public-releases of this package is generously sponsored
 by our employer http://www.sitegeist.de.*
 
 ## Usage
@@ -30,44 +36,55 @@ Settings.yaml
 
 ```yaml
 Sitegeist:
-   Silhouettes:
-       properties:
-          vendor:
-              text:
-                  block:
-                      type: string
-                      defaultValue: ''
-                      ui:
-                        inlineEditable: TRUE
-                        aloha:
-                          placeholder: i18n
-                          autoparagraph: TRUE
-                          'format':
-                            'strong': TRUE
-                            'em': TRUE
-                            'u': FALSE
-                            'sub': FALSE
-                            'sup': FALSE
-                            'del': FALSE
-                            'p': TRUE
-                            'h1': TRUE
-                            'h2': TRUE
-                            'h3': TRUE
-                            'pre': TRUE
-                            'removeFormat': TRUE
-                          'table':
-                            'table': TRUE
-                          'list':
-                            'ol': TRUE
-                            'ul': TRUE
-                          'link':
-                            'a': TRUE
+  Silhouettes:
+    properties:
+      vendor:
+        text:
+          block:
+            type: string
+            defaultValue: ''
+            ui:
+              inlineEditable: TRUE
+              aloha:
+                placeholder: i18n
+                autoparagraph: TRUE
+                'format':
+                  'strong': TRUE
+                  'em': TRUE
+                  'u': FALSE
+                  'sub': FALSE
+                  'sup': FALSE
+                  'del': FALSE
+                  'p': TRUE
+                  'h1': TRUE
+                  'h2': TRUE
+                  'h3': TRUE
+                  'pre': TRUE
+                  'removeFormat': TRUE
+                'table':
+                  'table': TRUE
+                'list':
+                  'ol': TRUE
+                  'ul': TRUE
+                'link':
+                  'a': TRUE
+      childNodes:
+        vendor:
+          defaultConstraints:
+            constraints:
+              'Neos.Neos:Content': TRUE
+              'Neos.NodeTypes.BaseMixins:TitleMixin': TRUE
+              'Neos.Demo:Constraint.Content.Carousel': TRUE
+              'Neos.Demo:Constraint.Content.Column': FALSE
 ```
 
 NodeTypes.yaml
 
 ```yaml
 'Vendor.Package:NodeTypeName':
+  childNodes:
+    options:
+      silhouette: 'vendor.defaultConstraints'    
   properties:
     description:
       ui:
@@ -86,7 +103,7 @@ NodeTypes.yaml
 
 ## Installation
 
-Sitegeist.Silhouettes is available via packagist. Add `"sitegeist/silhouettes" : "^1.0"` 
+Sitegeist.Silhouettes is available via packagist. Add `"sitegeist/silhouettes" : "^1.0"`
 to the require section of the composer.json or run `composer require sitegeist/silhouettes`.
 
 We use semantic-versioning so every breaking change will increase the major-version number.

--- a/README.md
+++ b/README.md
@@ -83,8 +83,12 @@ NodeTypes.yaml
 ```yaml
 'Vendor.Package:NodeTypeName':
   childNodes:
-    options:
-      silhouette: 'vendor.defaultConstraints'    
+    column1:
+      options:
+        silhouette: 'vendor.defaultConstraints'    
+    column2:
+      options:
+        silhouette: 'vendor.defaultConstraints'    
   properties:
     description:
       ui:


### PR DESCRIPTION
Extended SilhouettesNodeTypePostProcessor.php:
  - Now the childNodes namespace is supported as well as the properties namespace.
  - It is now possible to easily extend Silhouettes to support additional namespaces if required in the future